### PR TITLE
Fix jira-ticket-cli binary name mismatch

### DIFF
--- a/Casks/jira-ticket-cli.rb
+++ b/Casks/jira-ticket-cli.rb
@@ -9,7 +9,7 @@ cask "jira-ticket-cli" do
     skip "Auto-generated on release."
   end
 
-  binary "jira-ticket-cli"
+  binary "jtk", target: "jira-ticket-cli"
 
   on_macos do
     on_intel do


### PR DESCRIPTION
## Summary
- Fix cask install failure caused by binary name mismatch
- The release archive contains `jtk` but the cask was referencing `jira-ticket-cli`
- Use `target:` parameter to symlink `jtk` as `jira-ticket-cli`

## Test plan
- [x] Uninstall jira-ticket-cli if installed: `brew uninstall --cask jira-ticket-cli`
- [x] Add tap and install: `brew install --cask open-cli-collective/tap/jira-ticket-cli`
- [x] Verify `jira-ticket-cli` command works

Fixes #3