### PR TITLE
Remove invalid license field from casks

### DIFF
--- a/Casks/gmail-ro.rb
+++ b/Casks/gmail-ro.rb
@@ -1,6 +1,5 @@
 cask "gmail-ro" do
   version "1.0.6"
-  license "MIT"
 
   name "gmail-ro"
   desc "Read-only command-line interface for Gmail"

--- a/Casks/newrelic-cli.rb
+++ b/Casks/newrelic-cli.rb
@@ -1,6 +1,5 @@
 cask "newrelic-cli" do
   version "1.0.11"
-  license "MIT"
 
   name "newrelic-cli"
   desc "Command-line interface for New Relic"


### PR DESCRIPTION
## Summary
- Remove invalid `license` DSL method from gmail-ro and newrelic-cli casks
- The `license` method is only valid for Homebrew Formulas, not Casks
- Both casks were failing to install with: "Error: Unexpected method 'license' called on Cask"

## Test plan
- [x] Uninstall casks if installed: `brew uninstall --cask gmail-ro newrelic-cli`
- [x] Install gmail-ro: `brew install --cask open-cli-collective/tap/gmail-ro`
- [x] Install newrelic-cli: `brew install --cask open-cli-collective/tap/newrelic-cli`
- [x] Verify both commands are available

Fixes #1
Fixes #2