### PR TITLE
Add short-name casks (jtk, slck, nrq, gro)

### DIFF
--- a/Casks/jtk.rb
+++ b/Casks/jtk.rb
@@ -1,0 +1,43 @@
+cask "jtk" do
+  name "jtk"
+  desc "Command-line interface for Jira Cloud"
+  homepage "https://github.com/open-cli-collective/jira-ticket-cli"
+  version "0.1.20"
+
+  binary "jtk"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/open-cli-collective/jira-ticket-cli/releases/download/v#{version}/jtk_#{version}_darwin_amd64.tar.gz"
+      sha256 "5c9c6ea728eb3da4cda69affbcbeef0e79aeb7686e1d280be4662663cf953b5c"
+    end
+    on_arm do
+      url "https://github.com/open-cli-collective/jira-ticket-cli/releases/download/v#{version}/jtk_#{version}_darwin_arm64.tar.gz"
+      sha256 "623bdaa20b9c6594f2a982c4e68d0648ed9396644f780b0b0730559e541c02fd"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/open-cli-collective/jira-ticket-cli/releases/download/v#{version}/jtk_#{version}_linux_amd64.tar.gz"
+      sha256 "ff28d2a45d4c63d6a955a4e8248a2b6230f8b3a769b3fef22c80016dcc73162d"
+    end
+    on_arm do
+      url "https://github.com/open-cli-collective/jira-ticket-cli/releases/download/v#{version}/jtk_#{version}_linux_arm64.tar.gz"
+      sha256 "d83173304e1712e7f4442af377bc48e1d868b40e39bf865e4318b2c572283357"
+    end
+  end
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/jtk"]
+  end
+
+  caveats <<~EOS
+    jtk has been installed.
+
+    To configure, run:
+      jtk config set --domain DOMAIN --email EMAIL --token TOKEN
+
+    Get your API token from: https://id.atlassian.com/manage-profile/security/api-tokens
+  EOS
+end

--- a/Casks/slck.rb
+++ b/Casks/slck.rb
@@ -1,0 +1,44 @@
+cask "slck" do
+  name "slck"
+  desc "Command-line interface for Slack"
+  homepage "https://github.com/open-cli-collective/slack-chat-api"
+  version "3.1.20"
+
+  binary "slck"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slck_v#{version}_darwin_arm64.tar.gz"
+      sha256 "3c788e63092bca923fc761929d84bba043ed8a17f21ebea6435bdb796a7652de"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slck_v#{version}_darwin_amd64.tar.gz"
+      sha256 "95ec731163eafd129447cb6865caeed9af9ef1d648cc52c18ebdb4d5ca9a37ef"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slck_v#{version}_linux_arm64.tar.gz"
+      sha256 "da192f409252c6b03bf5213f37a647ce50d66dcd56d9284d634abbf5583c4afe"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slck_v#{version}_linux_amd64.tar.gz"
+      sha256 "2881a65a990ef78a49aace02273486c70966368c43e7687e9c48423dbf36eae6"
+    end
+  end
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/slck"]
+  end
+
+  caveats <<~EOS
+    slck has been installed.
+
+    To configure, run:
+      slck config set-token
+
+    On macOS, your token is stored securely in the system Keychain.
+    On Linux, your token is stored in ~/.config/slack-chat-api/credentials.
+  EOS
+end


### PR DESCRIPTION
## Summary
- Add `jtk.rb` cask as a short-name alias for jira-ticket-cli
- Add `slck.rb` cask as a short-name alias for slack-chat-cli
- Add `nrq.rb` cask as a short-name alias for newrelic-cli
- Add `gro.rb` cask as a short-name alias for google-readonly
- Allows users to install via `brew install open-cli-collective/homebrew-tap/{jtk,slck,nrq,gro}`

This completes the set of short-name casks, consistent with how `cfl` already works.

## Test plan
- [ ] `brew install open-cli-collective/homebrew-tap/jtk` installs successfully
- [ ] `jtk --version` works
- [ ] `brew install open-cli-collective/homebrew-tap/slck` installs successfully
- [ ] `slck --version` works
- [ ] `brew install open-cli-collective/homebrew-tap/nrq` installs successfully
- [ ] `nrq --version` works
- [ ] `brew install open-cli-collective/homebrew-tap/gro` installs successfully
- [ ] `gro --version` works

Fixes #6
Fixes #7
Addresses #8