### PR TITLE
Add nrq and gro casks, update README

### DIFF
--- a/Casks/gro.rb
+++ b/Casks/gro.rb
@@ -1,0 +1,44 @@
+cask "gro" do
+  name "gro"
+  desc "Read-only command-line interface for Google services"
+  homepage "https://github.com/open-cli-collective/google-readonly"
+  version "1.0.32"
+
+  binary "gro"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_darwin_arm64.tar.gz"
+      sha256 "a5cc1992c477b60347bbaf4661c8acde9315b51c42858d00067d8ed700341b6f"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_darwin_amd64.tar.gz"
+      sha256 "58e818028dcd892ae6f257314048ff1573ad0fd9c0be2cb0828cc368adfbd475"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_linux_arm64.tar.gz"
+      sha256 "7e1e8ace606a8acb72ec59e68489ba5926ef67a1f8fc36a276f7935fa230d3af"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/google-readonly/releases/download/v#{version}/gro_v#{version}_linux_amd64.tar.gz"
+      sha256 "8fb5f42258714e420149bfb89f95927b635431383b0001d3f4edb21e2f5232ea"
+    end
+  end
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gro"]
+  end
+
+  caveats <<~EOS
+    gro (google-readonly) has been installed.
+
+    To set up:
+    1. Create OAuth credentials at https://console.cloud.google.com/
+    2. Run: gro auth login
+
+    Available services: gmail, calendar, contacts, drive
+  EOS
+end

--- a/Casks/nrq.rb
+++ b/Casks/nrq.rb
@@ -1,0 +1,46 @@
+cask "nrq" do
+  name "nrq"
+  desc "Command-line interface for New Relic"
+  homepage "https://github.com/open-cli-collective/newrelic-cli"
+  version "1.0.26"
+
+  binary "nrq"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/open-cli-collective/newrelic-cli/releases/download/v#{version}/nrq_v#{version}_darwin_arm64.tar.gz"
+      sha256 "df683316e79d0f87d8a906d514399f87b6b50282e65eda9fed9895ed330fae4a"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/newrelic-cli/releases/download/v#{version}/nrq_v#{version}_darwin_amd64.tar.gz"
+      sha256 "22618201a6b1511b587fdee4929849ec7f42f9a67cee350999643fd4a8fdb68b"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/open-cli-collective/newrelic-cli/releases/download/v#{version}/nrq_v#{version}_linux_arm64.tar.gz"
+      sha256 "668963342cff649c67b8f01408437fddbf82533ab76a37280c786eea1e3a4338"
+    end
+    on_intel do
+      url "https://github.com/open-cli-collective/newrelic-cli/releases/download/v#{version}/nrq_v#{version}_linux_amd64.tar.gz"
+      sha256 "2d37d734498ad35a209e5520770aa852b071022e0a3ed8671e34673c4e776ede"
+    end
+  end
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/nrq"]
+  end
+
+  caveats <<~EOS
+    nrq has been installed.
+
+    To configure, run:
+      nrq config set-api-key
+      nrq config set-account-id
+
+    Or set environment variables:
+      export NEWRELIC_API_KEY=NRAK-xxx
+      export NEWRELIC_ACCOUNT_ID=123456
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -10,29 +10,49 @@ brew tap open-cli-collective/tap
 
 ## Available Tools
 
-| Tool | Description | Install |
-|------|-------------|---------|
-| [cfl](https://github.com/open-cli-collective/confluence-cli) | CLI for Atlassian Confluence | `brew install --cask cfl` |
-| [gmail-ro](https://github.com/open-cli-collective/gmail-ro) | Read-only CLI for Gmail | `brew install --cask gmail-ro` |
-| [newrelic-cli](https://github.com/open-cli-collective/newrelic-cli) | CLI for New Relic | `brew install --cask newrelic-cli` |
-| [slack-chat-api](https://github.com/open-cli-collective/slack-chat-api) | CLI for Slack | `brew install --cask slack-chat-api` |
+| Tool | Binary | Description | Install |
+|------|--------|-------------|---------|
+| [jira-ticket-cli](https://github.com/open-cli-collective/jira-ticket-cli) | `jtk` | CLI for Jira Cloud | `brew install --cask jtk` |
+| [slack-chat-api](https://github.com/open-cli-collective/slack-chat-api) | `slck` | CLI for Slack | `brew install --cask slck` |
+| [confluence-cli](https://github.com/open-cli-collective/confluence-cli) | `cfl` | CLI for Atlassian Confluence | `brew install --cask cfl` |
+| [newrelic-cli](https://github.com/open-cli-collective/newrelic-cli) | `nrq` | CLI for New Relic | `brew install --cask nrq` |
+| [google-readonly](https://github.com/open-cli-collective/google-readonly) | `gro` | Read-only CLI for Google services | `brew install --cask gro` |
+| [cpm](https://github.com/open-cli-collective/cpm) | `cpm` | Claude plugin manager | `brew install --cask cpm` |
+
+### Legacy Names
+
+For backwards compatibility, these aliases are also available:
+
+| Alias | Points To |
+|-------|-----------|
+| `jira-ticket-cli` | `jtk` |
+| `slack-chat-cli` | `slck` |
+| `newrelic-cli` | `nrq` |
+| `gmail-ro` | Legacy Gmail-only CLI |
+| `google-readonly` | `gro` |
 
 ## Usage
 
-After tapping, install any tool:
+After tapping, install any tool using the short name:
 
 ```bash
+# Jira CLI
+brew install --cask jtk
+
+# Slack CLI
+brew install --cask slck
+
 # Confluence CLI
 brew install --cask cfl
 
-# Gmail (read-only)
-brew install --cask gmail-ro
-
 # New Relic CLI
-brew install --cask newrelic-cli
+brew install --cask nrq
 
-# Slack CLI
-brew install --cask slack-chat-api
+# Google services CLI (Gmail, Calendar, Contacts, Drive)
+brew install --cask gro
+
+# Claude plugin manager
+brew install --cask cpm
 ```
 
 ## Updating


### PR DESCRIPTION
## Summary
- Add `nrq.rb` cask for newrelic-cli (v1.0.26)
- Add `gro.rb` cask for google-readonly (v1.0.32)
- Update README with all available casks and short binary names
- Document legacy name aliases for backwards compatibility

This completes the short-name cask set alongside jtk, slck, and cfl.

## Test plan
- [x] `brew install --cask open-cli-collective/homebrew-tap/nrq` works
- [x] `nrq --version` works
- [x] `brew install --cask open-cli-collective/homebrew-tap/gro` works
- [x] `gro --version` works

Addresses #8