### PR TITLE
Migrate depends_on macos: to symbol form

### DIFF
--- a/Casks/qlmarkdown2.rb
+++ b/Casks/qlmarkdown2.rb
@@ -12,7 +12,7 @@ cask "qlmarkdown2" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "QLMarkdown.app"
 

--- a/Casks/qlmarkdown2.rb
+++ b/Casks/qlmarkdown2.rb
@@ -12,7 +12,7 @@ cask "qlmarkdown2" do
     strategy :github_latest
   end
 
-  depends_on macos: :big_sur
+  depends_on macos: ">= :big_sur"
 
   app "QLMarkdown.app"
 

--- a/Casks/swiftmarkdown.rb
+++ b/Casks/swiftmarkdown.rb
@@ -12,7 +12,7 @@ cask "swiftmarkdown" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "SwiftMarkdown.app"
 


### PR DESCRIPTION
## Summary

Homebrew deprecated the string-comparison form of `depends_on macos:` in casks. The user-visible warning:

> Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.

The symbol form already means "that version or newer," so this is a pure syntax migration with no behavior change for end users.

- `Casks/swiftmarkdown.rb`: `">= :ventura"` → `:ventura`

## Test plan

- [x] `brew style Casks/swiftmarkdown.rb` no longer reports the deprecation
- [ ] Cask audit CI green

Closes #17