### PR TITLE
[codex] add repo-local codereview agent

### DIFF
--- a/.codereview/agents/packaging/brew-tap-integrity/index.yaml
+++ b/.codereview/agents/packaging/brew-tap-integrity/index.yaml
@@ -1,0 +1,13 @@
+name: brew-tap-integrity
+description: Reviews Homebrew tap changes for generated package integrity and release coherence.
+model_tier: small
+effort: low
+file_globs:
+  - Casks/**/*.rb
+  - Formula/**/*.rb
+  - README*
+  - .github/workflows/**/*
+  - .codereview/**
+applies_when:
+  - Homebrew tap packaging files, generated casks or formulae, release metadata, or codereview reviewer definitions change.
+needs_full_file_content: false

--- a/.codereview/agents/packaging/brew-tap-integrity/prompt.md
+++ b/.codereview/agents/packaging/brew-tap-integrity/prompt.md
@@ -1,0 +1,15 @@
+Review Homebrew tap changes for Open CLI Collective package integrity.
+
+Focus on high-signal issues only. Prefer 0-5 findings. Return no findings when the diff is acceptable. Avoid broad style feedback.
+
+Check:
+- Generated cask and formula invariants remain intact and generated files are not being manually edited in unsafe ways.
+- Version, URL, and checksum values are mutually coherent.
+- macOS and Linux architecture blocks resolve to the correct artifacts.
+- Binary names, installed paths, and exposed commands match the packaged tool.
+- Postflight quarantine removal, caveats, and uninstall or cleanup behavior still make sense.
+- Formula resource URLs and checksums are complete and consistent.
+- Homebrew tests still exercise a meaningful installed command.
+- Backwards-compatible cask aliases or migration paths are preserved when names change.
+
+Report only concrete integrity, packaging, or upgrade risks.

--- a/.codereview/agents/packaging/index.yaml
+++ b/.codereview/agents/packaging/index.yaml
@@ -1,0 +1,3 @@
+name: packaging
+description: Reviewers for package and distribution integrity checks.
+owner: open-cli-collective


### PR DESCRIPTION
## Summary
- add a repo-local `.codereview` reviewer for Homebrew tap package integrity
- scope the reviewer to casks, formulae, README/workflows, and future `.codereview` changes
- use a tiny `small`/`low` reviewer profile for this narrow repo

## Validation
- `cr --profile codex-rianjs-bot agents list --agents-dir .codereview/agents --json`
